### PR TITLE
Add support for unicode nicknames

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/AndrewBelt/hack.chat",
   "dependencies": {
-    "ws": "^0.7.2"
+    "ws": "^0.7.2",
+    "xregexp": "2.0.0"
   },
   "engines": {
     "node": ">=0.12.0"

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 var fs = require('fs')
 var ws = require('ws')
+var XRegExp = require('xregexp').XRegExp
 
 var config = JSON.parse(fs.readFileSync('./config.json'))
 
@@ -63,7 +64,8 @@ function broadcast(data, channel) {
 function nicknameValid(nick) {
 	if (/[$,*!?]/.test(nick)) return false
 	// allow all other "normal" ascii characters
-	return /^[\x20-\x7e]{1,32}$/.test(nick)
+  var unicodeNick = XRegExp('^[\\p{L}\\p{N}]{1,32}')
+	return unicodeNick.test(nick)
 }
 
 function getAddress(client) {


### PR DESCRIPTION
Using XRegExp for adding unicode support to the regex check for valid nicknames in order to resolve #9 
