### PR TITLE
Highlight messages for user's nick

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -154,6 +154,9 @@ function pushMessage(args) {
 	else if (args.nick == '*') {
 		messageEl.classList.add('info')
 	}
+	else if (args.text && args.text.indexOf("@" + myNick + " ") != -1) {
+		messageEl.classList.add('direct')
+	}
 
 	// Nickname
 	var nickSpanEl = document.createElement('span')

--- a/client/client.js
+++ b/client/client.js
@@ -154,7 +154,7 @@ function pushMessage(args) {
 	else if (args.nick == '*') {
 		messageEl.classList.add('info')
 	}
-	else if (args.text && args.text.indexOf("@" + myNick + " ") != -1) {
+	else if (args.text && args.text.indexOf("@" + myNick.split("#")[0] + " ") != -1) {
 		messageEl.classList.add('direct')
 	}
 

--- a/client/scheme.less
+++ b/client/scheme.less
@@ -56,6 +56,12 @@ input, textarea {
   }
 }
 
+.direct {
+  .text {
+    color: @base09;
+  }
+}
+
 #footer {
   background: @base00;
 }

--- a/client/style.less
+++ b/client/style.less
@@ -100,6 +100,10 @@ ul {
 	margin: 0;
 }
 
+.direct .text {
+	font-weight: bold;
+}
+
 #footer {
 	position: fixed;
 	bottom: 0;


### PR DESCRIPTION
Currently, a user can direct a message at you with @nickname, but it can easily get lost in the spam. These messages should be visually distinguished so it's easier to follow a conversation in a busy channel.
