### PR TITLE
Make links relative so they work anywhere

### DIFF
--- a/client/index.jade
+++ b/client/index.jade
@@ -4,11 +4,11 @@ html
 		meta(name="viewport", content="width=device-width, initial-scale=1")
 		meta(charset="utf-8")
 		title hack.chat
-		link(rel="stylesheet", href="/style.css")
-		link(rel="stylesheet", href="/katex/katex.min.css")
-		link#scheme-link(rel="stylesheet", href="/schemes/atelier-dune.css")
-		script(src="/katex/katex.min.js")
-		script(src="/katex/contrib/auto-render.min.js")
+		link(rel="stylesheet", href="style.css")
+		link(rel="stylesheet", href="katex/katex.min.css")
+		link#scheme-link(rel="stylesheet", href="schemes/atelier-dune.css")
+		script(src="katex/katex.min.js")
+		script(src="katex/contrib/auto-render.min.js")
 	body
 		article.container
 			#messages.messages
@@ -38,4 +38,4 @@ html
 				p (Click user to invite)
 				ul#users
 
-		script(src="/client.js")
+		script(src="client.js")


### PR DESCRIPTION
Before links were relative so they'd work on localhost but not when you use nginx or apache to serve the application from a sub-directory. Relative links will work with both localhost and in a website directory.