### PR TITLE
Fixed socket memory overflow

### DIFF
--- a/server.js
+++ b/server.js
@@ -41,6 +41,9 @@ server.on('connection', function(socket) {
 
 			// ignore ridiculously large packets
 			if (data.length > 65536) {
+				// Socket buffer likely not being flushed quickly enough or it's an attack,
+				// In either case, since we cannot flush the socket, we should kill it
+				socket.close()
 				return
 			}
 			var args = JSON.parse(data)
@@ -51,6 +54,9 @@ server.on('connection', function(socket) {
 			}
 		}
 		catch (e) {
+			// Socket sent malformed JSON or buffer contains invalid JSON
+			// Since we cannot flush the socket, and for security reasons, we should kill it
+			socket.close()
 			console.warn(e.stack)
 		}
 	})


### PR DESCRIPTION
A fix for the socket memory overflow bug ( discovered by @wwandrew ).

This fault is due to the socket's buffer getting filled to quickly without having a chance to flush. Since the message event in server.js is unable to flush the socket, disconnection is the best applied fix.

An alternate patch would be to increase the maxPayload (using ws options), however this may not cover all cases.